### PR TITLE
Breaking: extend from AirBnB and simplify rules list

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,13 @@ $ npm i eslint --save-dev
 Next, install `eslint-plugin-internations` and its peer dependencies:
 
 ```
-$ npm install eslint-plugin-internations eslint-plugin-react babel-eslint --save-dev
+(
+  export PKG=eslint-plugin-internations;
+  npm info "$PKG@latest" peerDependencies --json | command sed 's/[\{\},]//g ; s/@/@/g' | xargs npm install --save-dev "$PKG@latest"
+)
 ```
 
-**Note:** If you installed ESLint globally (using the `-g` flag) then you must also install `eslint-plugin-internations` globally.
+**Note:** If you installed ESLint globally (using the `-g` flag) then you must also install `eslint-plugin-internations` and its peer dependencies globally.
 
 ## Usage
 

--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -4,12 +4,10 @@ module.exports = {
 
     'plugins': [
         'internations',
-        'react',
     ],
 
     'extends': [
-        'eslint:recommended',
-        'plugin:react/recommended',
+        'airbnb',
     ],
 
     'env': {
@@ -17,15 +15,6 @@ module.exports = {
         'browser': true,
         'commonjs': true, // for webpack
         'es6': true,
-    },
-
-    'parserOptions': {
-        'ecmaVersion': 6,
-        'sourceType': 'module',
-        'ecmaFeatures': {
-            'jsx': true,
-            'experimentalObjectRestSpread': true,
-        },
     },
 
     'settings': {
@@ -41,65 +30,25 @@ module.exports = {
 
     'rules': {
         // Max line length
-        'max-len': ['error', 120],
+        'max-len': ['error', 120, 2, {
+            'ignoreUrls': true,
+            'ignoreComments': false,
+            'ignoreRegExpLiterals': true,
+            'ignoreStrings': true,
+            'ignoreTemplateLiterals': true,
+        }],
 
-        // Enforces parentheses around arrow function parameters, except when there is only one argument
-        'arrow-parens': ['error', 'as-needed', { 'requireForBlockBody': true }],
+        // Disallow spaces between the function name or function keyword and the opening parenthesis
+        "space-before-function-paren": ["error", "never"],
 
-        // Enforce trailing commas in multiline object/array literals
-        'comma-dangle': ['error', 'always-multiline'],
-
-        // Use const
-        'prefer-const': 'error',
-
-        // Can't change const
-        'no-const-assign': 'error',
-
-        // Don't allow vars
-        'no-var': 'error',
-
-        // Prefer object shorthand
-        'object-shorthand': 'error',
-
-        // Disallow declaration of variables already declared in the outer scope
-        'no-shadow': 'off',
-        // Disallow use of new operator when not part of the assignment or comparison
-        'no-new': 'off',
-        // Enforce usage of semicolon
-        'semi': 'error',
-        // Allow dangling underscores in identifiers
-        'no-underscore-dangle': 'off',
-        // Disallow use of multiple spaces
-        'no-multi-spaces': 'off',
         // Require return statements to either always or never specify values
         'consistent-return': 'off',
-        'curly': 'error',
-        // Disallow Primitive wrapper instances
-        'no-new-wrappers': 'error',
-        // Disallow the use of the Object constructor
-        'no-new-object': 'error',
-        // Disallow Function constructor
-        'no-new-func': 'error',
-        // Disallow reassignment of native Objects
-        'no-native-reassign': 'error',
-        // Disallow extending of native Objects
-        'no-extend-native': 'error',
-        // Disallow functions in loops
-        'no-loop-func': 'error',
-        // Disallow unnecessary nested blocks
-        'no-lone-blocks': 'error',
-        // No constant expressions inside conditions
-        'no-constant-condition': 'error',
-        'no-eval': 'error',
-        'no-implied-eval': 'error',
-        // Disallow unnecessary function binding
-        'no-extra-bind': 'error',
-        // Disallow the use of `arguments.caller` and `arguments.callee`
-        'no-caller': 'error',
+
         // Disallow the type conversion with shorter notations.
         'no-implicit-coercion': 'error',
-        // Enforce spacing around the * in generator functions
-        'generator-star-spacing': ['error', { 'before': false, 'after': true }],
+
+        // No constant expressions inside conditions (airbnb uses "warn")
+        'no-constant-condition': 'error',
 
         // one declaration for uninitialized variables, one declaration PER initializer variable
         'one-var': ['error', {
@@ -107,145 +56,18 @@ module.exports = {
             'initialized': 'never',
         }],
 
-        // Disallow use of variables before they are defined
-        // except named function definitions
-        'no-use-before-define': ['error', 'nofunc'],
-        // No with Statements
-        'no-with': 'error',
-        'no-multiple-empty-lines': 'error',
-        // Enforce single quotes
-        'quotes': ['error', 'single'],
-        // Enforce type-safe equality operators `===` and `!==`
-        'eqeqeq': ['error', 'allow-null'],
-        // Require immediate function invocation to be wrapped in parentheses
-        'wrap-iife': ['error', 'inside'],
-        // Encourages use of dot notation whenever possible
-        'dot-notation': ['error', { 'allowKeywords': true }],
-        // Disallow declaration of variables that are not used in the code
-        'no-unused-vars': 'error',
-        // Prefer the array literal notation [] to construct arrays
-        'no-array-constructor': 'error',
-        // Disallow Use of the Comma Operator
-        'no-sequences': 'error',
-        // Ensures that all function bodies are strict mode code, while global code is not
-        'strict': ['error', 'safe'],
-        // Require file to end with single newline
-        'eol-last': 'error',
-        'no-unused-expressions': 'error',
-        // Disallow initializing to undefined
-        'no-undef-init': 'error',
-        // Disallow spaces in function calls
-        'no-spaced-func': 'error',
-        'no-shadow-restricted-names': 'error',
-        // Disallow javascript: URLs
-        'no-script-url': 'error',
-        // Disallow assignment in return statement
-        'no-return-assign': ['error', 'except-parens'],
-        // Enforce hasOwnProperty() checks in for loops
-        'guard-for-in': 'error',
-        // Disallow labels.
-        // Useful for catching arrow functions that wanted to return an object but forgot the parenthesis:
-        // bad:
-        // const fn = (state) => {
-        //     foo: 'foo'
-        // };
-        //
-        // good:
-        // const fn = (state) => ({
-        //     foo: 'foo'
-        // });
-        'no-labels': 'error',
-        'no-restricted-properties': ['error', {
-            'object': '_',
-            'property': 'extend',
-            'message': 'Please use Object.assign instead.',
-        }, {
-            'object': '$',
-            'property': 'post',
-            'message': 'Please io.post instead',
-        }, {
-            'object': '$',
-            'property': 'ajax',
-            'message': 'Please io.ajax instead',
-        }, {
-            'object': '$',
-            'property': 'load',
-            'message': 'Please io.load instead',
-        }, {
-            'object': '$',
-            'property': 'get',
-            'message': 'Please io.get instead',
-        }, {
-            'object': '$',
-            'property': 'getScript',
-            'message': 'Please io.ajax instead',
-        }, {
-            'object': 'jQuery',
-            'property': 'post',
-            'message': 'Please io.post instead',
-        }, {
-            'object': 'jQuery',
-            'property': 'ajax',
-            'message': 'Please io.ajax instead',
-        }, {
-            'object': 'jQuery',
-            'property': 'load',
-            'message': 'Please io.load instead',
-        }, {
-            'object': 'jQuery',
-            'property': 'get',
-            'message': 'Please io.get instead',
-        }, {
-            'object': 'jQuery',
-            'property': 'getScript',
-            'message': 'Please io.ajax instead',
-        }],
-
-        //------------------------------------------------------------------------------
-        // Stylistic rules
-        //------------------------------------------------------------------------------
-
-        // Require camelcasing when naming variables
-        'camelcase': 'error',
-        // Disallow Yoda conditions
-        'yoda': ['error', 'never'],
-        // Enforce one true comma style: before line break
-        'comma-style': ['error', 'last'],
-        // Enforce spacing after commas
-        'comma-spacing': ['error', { 'before': false, 'after': true }],
-        // No spacing before semicolons, enforce space after semicolon
-        'semi-spacing': ['error', { 'before': false, 'after': true }],
-        // Enforces spacing after the colon in object literal properties, and no spacing before
-        'key-spacing': ['error', { 'beforeColon': false, 'afterColon': true }],
-        // Require spaces around infix operators
-        'space-infix-ops': 'error',
-        // Require spaces following return, throw, and case
-        'keyword-spacing': 'error',
         // Disallow quotes around object literal property names, except when they are strictly required
         'quote-props': ['error', 'as-needed', { 'numbers': true }],
-        // Enforce spaces inside of curly braces in objects
-        'object-curly-spacing': ['error', 'always'],
-        // Only allow LF (UNIX-style) linebreaks
-        'linebreak-style': ['error', 'unix'],
-        'no-trailing-spaces': 'error',
-        // Require consistent naming `that` when declaring an alias for `this`
-        'consistent-this': ['error', 'that'],
-        // Enforces "one true brace style"
-        'brace-style': ['error', '1tbs', { 'allowSingleLine': true }],
-        // Disallow spaces between the function name or function keyword and the opening parenthesis
-        'space-before-function-paren': ['error', 'never'],
-        // Disallow spaces inside parentheses
-        'space-in-parens': 'error',
-        // Require space before blocks
-        'space-before-blocks': 'error',
+
         // 4 spaces indentation
         'indent': ['error', 4, { 'SwitchCase': 1 }],
-        // Disallow spaces inside array brackets
-        'array-bracket-spacing': ['error', 'never'],
-        // Require spaces before/after word unary operators (e.g. typeof), forbid for non-words (e.g. ++foo)
-        'space-unary-ops': ['error', { 'words': true, 'nonwords': false }],
-        // Require parens when invoking a constructor
-        'new-parens': 'error',
+
+        // airbnb sets this to 'object'
+        'dot-location': ['error', 'property'],
+
+        // airbnb sets this to 'warn'
+        'func-names': 'off',
+
         // Require a capital letter for constructors
         'new-cap': ['error', {
             'capIsNewExceptions': [
@@ -267,108 +89,124 @@ module.exports = {
             ],
         }],
 
+        'no-restricted-properties': ['error', {
+            'object': '_',
+            'property': 'extend',
+            'message': 'Please use Object.assign instead.',
+        }, {
+            'object': '$',
+            'property': 'post',
+            'message': 'Please use io.post instead',
+        }, {
+            'object': '$',
+            'property': 'ajax',
+            'message': 'Please use io.ajax instead',
+        }, {
+            'object': '$',
+            'property': 'load',
+            'message': 'Please use io.load instead',
+        }, {
+            'object': '$',
+            'property': 'get',
+            'message': 'Please use io.get instead',
+        }, {
+            'object': '$',
+            'property': 'getScript',
+            'message': 'Please use io.ajax instead',
+        }, {
+            'object': 'jQuery',
+            'property': 'post',
+            'message': 'Please use io.post instead',
+        }, {
+            'object': 'jQuery',
+            'property': 'ajax',
+            'message': 'Please use io.ajax instead',
+        }, {
+            'object': 'jQuery',
+            'property': 'load',
+            'message': 'Please use io.load instead',
+        }, {
+            'object': 'jQuery',
+            'property': 'get',
+            'message': 'Please use io.get instead',
+        }, {
+            'object': 'jQuery',
+            'property': 'getScript',
+            'message': 'Please use io.ajax instead',
+        }],
+
+        // -------------------------------------------------
+        // These should be enabled when not in "legacy" code:
+        // -------------------------------------------------
+
+        // Disallow declaration of variables already declared in the outer scope
+        'no-shadow': 'off',
+
+        // Disallow use of new operator when not part of the assignment or comparison
+        'no-new': 'off',
+
+        // Allow dangling underscores in identifiers
+        'no-underscore-dangle': 'off',
+
+        'comma-dangle': ['error', {
+            'arrays': 'always-multiline',
+            'objects': 'always-multiline',
+            'imports': 'always-multiline',
+            'exports': 'always-multiline',
+            'functions': 'never', // airbnb sets this to 'always-multiline'
+        }],
+
+        'no-param-reassign': 'off',
+        'prefer-rest-params': 'off',
+        'prefer-spread': 'off',
+        'no-plusplus': 'off',
+        'no-restricted-syntax': 'off',
+        'default-case': 'off',
+        'no-multi-assign': 'off',
+        'no-prototype-builtins': 'off',
+        'no-mixed-operators': 'off',
+        'no-useless-escape': 'off',
+        'no-use-before-define': 'off',
+        'no-continue': 'off',
+        'no-lonely-if': 'off',
+        'import/prefer-default-export': 'off',
+
         //------------------------------------------------------------------------------
         // React and JSX rules
         //------------------------------------------------------------------------------
 
-        // Prefer classes
-        'react/prefer-es6-class': 'error',
-
-        // Prefer stateless
-        'react/prefer-stateless-function': 'error',
-
-        // Require prop types
-        'react/prop-types': ['error', { 'ignore': [], 'customValidators': [] }],
-
         'react/forbid-prop-types': ['error', { 'forbid': ['any', 'array'] }],
 
-        // Multiple line returns must be wrapped in parens
-        'react/jsx-wrap-multilines': ['error', {
-            'declaration': true,
-            'assignment': true,
-            'return': true,
-        }],
-
-        // Always close tags that have no children
-        'react/self-closing-comp': 'error',
-
-        // Space before self-closing
-        'react/jsx-space-before-closing': ['error', 'always'],
-
-        // Sort ordering
-        'react/sort-comp': ['error', {
-            'order': [
-                'static-methods',
-                'lifecycle',
-                '/^on.+$/',
-                '/^(get|set)(?!(InitialState$|DefaultProps$|ChildContext$)).+$/',
-                'everything-else',
-                '/^render.+$/',
-                'render',
-            ],
-        }],
-
-        // No undeclared vars in JSX
-        'react/jsx-no-undef': 'error',
-
-        // Intent props 4 spaces too
+        // indent jsx and jsx props 4 spaces
         'react/jsx-indent-props': ['error', 4],
+        'react/jsx-indent': ['error', 4],
+
+        // allow jsx in files named .js
+        'react/jsx-filename-extension': 'off',
 
         // align to the right of the last prop
         'react/jsx-closing-bracket-location': ['warn', 'tag-aligned'],
-
         'react/sort-prop-types': ['error', {
             'ignoreCase': true,
             'callbacksLast': false,
         }],
 
-        // Prevent React being marked as unused
-        'react/jsx-uses-react': ['error'],
-
-        // Prevent variables used being marked as unused
-        'react/jsx-uses-vars': 'error',
-
-        // Naming
-        'react/jsx-pascal-case': 'error',
-
-        // No deprecated stuff
-        'react/no-deprecated': ['warn'],
-
-        // Prevent usage of setState in componentDidMount
-        'react/no-did-mount-set-state': 'error',
-
-        // Prevent usage of setState in componentDidUpdate
-        'react/no-did-update-set-state': 'error',
-
         // Prevent direct mutation of this.state
         'react/no-direct-mutation-state': 'error',
 
-        // Prevent usage of isMounted
-        'react/no-is-mounted': 'error',
+        // Require defaultProp for every non-required prop
+        'react/require-default-props': 'off',
 
-        // Prevent multiple component definition per file
-        'react/no-multi-comp': ['error', { 'ignoreStateless': true }],
+        'jsx-a11y/no-static-element-interactions': 'off',
+        'jsx-a11y/label-has-for': 'off',
 
-        // Prefer double quotes
-        'jsx-quotes': 'error',
+        //------------------------------------------------------------------------------
+        // Import plugin
+        //------------------------------------------------------------------------------
 
-        // Omit superfluous true on props
-        'react/jsx-boolean-value': 'error',
-
-        // No prop duplicates
-        'react/jsx-no-duplicate-props': 'error',
-
-        // No strings in JSX
-        'react/no-string-refs': 'error',
-
-        // No unknown props
-        'react/no-unknown-property': 'error',
-
-        // React in scope
-        'react/react-in-jsx-scope': 'error',
-
-        // Prevent usage of Array index in keys
-        'react/no-array-index-key': 'error',
+        'import/no-extraneous-dependencies': 'off',
+        'import/no-unresolved': 'off',
+        'import/extensions': 'off',
 
         //------------------------------------------------------------------------------
         // Custom rules
@@ -376,16 +214,21 @@ module.exports = {
 
         // Restrict _.bindAll to be used without method names
         'internations/valid-bindall': 'off',
+
         // Disallow any ViewComponent usage
         // restrict usage of `new` operator for View Components instantiation
         'internations/no-view-components': 'error',
         'internations/no-view-create': 'error',
+
         // Allow only one signature for modules definition
         'internations/valid-define': 'error',
+
         // Don't allow fdescribe
         'internations/no-fdescribe': 'error',
+
         // Don't allow fit
         'internations/no-fit': 'error',
+
         'internations/routes': 'error',
         'internations/no-object-defaults': 'error',
         'internations/return-this-from-render': 'error',

--- a/package.json
+++ b/package.json
@@ -5,17 +5,21 @@
   "author": "Vitor Balocco <vitorbal@gmail.com>",
   "main": "lib/index.js",
   "dependencies": {
+    "babel-eslint": "^7.1.1",
+    "eslint-config-airbnb": "^14.1.0",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^4.0.0",
+    "eslint-plugin-react": "^6.10.0",
     "esprima": "^3.1.1",
     "esprima-walk": "^0.1.0",
     "requireindex": "~1.1.0"
   },
   "devDependencies": {
-    "eslint": "^3.6.1"
+    "eslint": "^3.15.0"
   },
   "peerDependencies": {
-    "eslint": ">= 3.6.1 < 4",
-    "eslint-plugin-react": ">= 6.9.0 < 7",
-    "babel-eslint": ">= 7.0.0 < 8"
+    "babel-eslint": "^7.0.0",
+    "eslint": "^3.15.0"
   },
   "scripts": {
     "lint": "eslint ./lib"

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,6 +45,12 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+aria-query@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-0.3.0.tgz#cb8a9984e2862711c83c80ade5b8f5ca0de2b467"
+  dependencies:
+    ast-types-flow "0.0.7"
+
 array-union@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
@@ -55,17 +61,78 @@ array-uniq@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
 
+array.prototype.find@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/array.prototype.find/-/array.prototype.find-2.0.3.tgz#08c3ec33e32ec4bab362a2958e686ae92f59271d"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.7.0"
+
 arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
-babel-code-frame@^6.16.0:
+ast-types-flow@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
+
+babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
     chalk "^1.1.0"
     esutils "^2.0.2"
     js-tokens "^3.0.0"
+
+babel-eslint@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-7.1.1.tgz#8a6a884f085aa7060af69cfc77341c2f99370fb2"
+  dependencies:
+    babel-code-frame "^6.16.0"
+    babel-traverse "^6.15.0"
+    babel-types "^6.15.0"
+    babylon "^6.13.0"
+    lodash.pickby "^4.6.0"
+
+babel-messages@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
+  dependencies:
+    babel-runtime "^6.22.0"
+
+babel-runtime@^6.22.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
+
+babel-traverse@^6.15.0:
+  version "6.23.1"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.23.1.tgz#d3cb59010ecd06a97d81310065f966b699e14f48"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    babel-messages "^6.23.0"
+    babel-runtime "^6.22.0"
+    babel-types "^6.23.0"
+    babylon "^6.15.0"
+    debug "^2.2.0"
+    globals "^9.0.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
+babel-types@^6.15.0, babel-types@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.23.0.tgz#bb17179d7538bad38cd0c9e115d340f77e7e9acf"
+  dependencies:
+    babel-runtime "^6.22.0"
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^1.0.1"
+
+babylon@^6.13.0, babylon@^6.15.0:
+  version "6.15.0"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.15.0.tgz#ba65cfa1a80e1759b0e89fb562e27dccae70348e"
 
 balanced-match@^0.4.1:
   version "0.4.2"
@@ -81,6 +148,10 @@ brace-expansion@^1.0.0:
 buffer-shims@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/buffer-shims/-/buffer-shims-1.0.0.tgz#9978ce317388c649ad8793028c3477ef044a8b51"
+
+builtin-modules@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
 
 caller-path@^0.1.0:
   version "0.1.0"
@@ -136,6 +207,14 @@ concat-stream@^1.4.6:
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
 
+contains-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
+
+core-js@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
+
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -146,7 +225,17 @@ d@^0.1.1, d@~0.1.1:
   dependencies:
     es5-ext "~0.10.2"
 
-debug@^2.1.1:
+damerau-levenshtein@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.3.tgz#ae4f4ce0b62acae10ff63a01bb08f652f5213af2"
+
+debug@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
+  dependencies:
+    ms "0.7.1"
+
+debug@^2.1.1, debug@^2.2.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
   dependencies:
@@ -155,6 +244,13 @@ debug@^2.1.1:
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+
+define-properties@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
+  dependencies:
+    foreach "^2.0.5"
+    object-keys "^1.0.8"
 
 del@^2.0.2:
   version "2.2.2"
@@ -168,12 +264,33 @@ del@^2.0.2:
     pinkie-promise "^2.0.0"
     rimraf "^2.2.8"
 
-doctrine@^1.2.2:
+doctrine@1.5.0, doctrine@^1.2.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
   dependencies:
     esutils "^2.0.2"
     isarray "^1.0.0"
+
+emoji-regex@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-6.1.0.tgz#d14ef743a7dfa6eaf436882bd1920a4aed84dd94"
+
+es-abstract@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.7.0.tgz#dfade774e01bfcd97f96180298c449c8623fb94c"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.0"
+    is-callable "^1.1.3"
+    is-regex "^1.0.3"
+
+es-to-primitive@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
+  dependencies:
+    is-callable "^1.1.1"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.1"
 
 es5-ext@^0.10.7, es5-ext@^0.10.8, es5-ext@~0.10.11, es5-ext@~0.10.2, es5-ext@~0.10.7:
   version "0.10.12"
@@ -240,7 +357,68 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint@^3.6.1:
+eslint-config-airbnb-base@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.1.0.tgz#dc9b3ec70b8c74dcbe6d6257c9da3992c39ca2ca"
+
+eslint-config-airbnb@^14.1.0:
+  version "14.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-airbnb/-/eslint-config-airbnb-14.1.0.tgz#355d290040bbf8e00bf8b4b19f4b70cbe7c2317f"
+  dependencies:
+    eslint-config-airbnb-base "^11.1.0"
+
+eslint-import-resolver-node@^0.2.0:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz#5add8106e8c928db2cba232bcd9efa846e3da16c"
+  dependencies:
+    debug "^2.2.0"
+    object-assign "^4.0.1"
+    resolve "^1.1.6"
+
+eslint-module-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.0.0.tgz#a6f8c21d901358759cdc35dbac1982ae1ee58bce"
+  dependencies:
+    debug "2.2.0"
+    pkg-dir "^1.0.0"
+
+eslint-plugin-import@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz#72ba306fad305d67c4816348a4699a4229ac8b4e"
+  dependencies:
+    builtin-modules "^1.1.1"
+    contains-path "^0.1.0"
+    debug "^2.2.0"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.2.0"
+    eslint-module-utils "^2.0.0"
+    has "^1.0.1"
+    lodash.cond "^4.3.0"
+    minimatch "^3.0.3"
+    pkg-up "^1.0.0"
+
+eslint-plugin-jsx-a11y@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-4.0.0.tgz#779bb0fe7b08da564a422624911de10061e048ee"
+  dependencies:
+    aria-query "^0.3.0"
+    ast-types-flow "0.0.7"
+    damerau-levenshtein "^1.0.0"
+    emoji-regex "^6.1.0"
+    jsx-ast-utils "^1.0.0"
+    object-assign "^4.0.1"
+
+eslint-plugin-react@^6.10.0:
+  version "6.10.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-6.10.0.tgz#9c48b48d101554b5355413e7c64238abde6ef1ef"
+  dependencies:
+    array.prototype.find "^2.0.1"
+    doctrine "^1.2.2"
+    has "^1.0.1"
+    jsx-ast-utils "^1.3.4"
+    object.assign "^4.0.4"
+
+eslint@^3.15.0:
   version "3.15.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.15.0.tgz#bdcc6a6c5ffe08160e7b93c066695362a91e30f2"
   dependencies:
@@ -342,6 +520,13 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
+find-up@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
+  dependencies:
+    path-exists "^2.0.0"
+    pinkie-promise "^2.0.0"
+
 flat-cache@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-1.2.2.tgz#fa86714e72c21db88601761ecf2f555d1abc6b96"
@@ -351,9 +536,17 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
+function-bind@^1.0.2, function-bind@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
 generate-function@^2.0.0:
   version "2.0.0"
@@ -376,7 +569,7 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-globals@^9.14.0:
+globals@^9.0.0, globals@^9.14.0:
   version "9.15.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.15.0.tgz#7a5d8fd865e69de910b090b15a87772f9423c5de"
 
@@ -400,6 +593,12 @@ has-ansi@^2.0.0:
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
   dependencies:
     ansi-regex "^2.0.0"
+
+has@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
+  dependencies:
+    function-bind "^1.0.2"
 
 ignore@^3.2.0:
   version "3.2.2"
@@ -442,6 +641,20 @@ interpret@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.1.tgz#d579fb7f693b858004947af39fa0db49f795602c"
 
+invariant@^2.2.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
+  dependencies:
+    loose-envify "^1.0.0"
+
+is-callable@^1.1.1, is-callable@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
 is-fullwidth-code-point@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
@@ -481,11 +694,19 @@ is-property@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
 
+is-regex@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.3.tgz#0d55182bddf9f2fde278220aec3a75642c908637"
+
 is-resolvable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.0.0.tgz#8df57c61ea2e3c501408d100fb013cf8d6e0cc62"
   dependencies:
     tryit "^1.0.1"
+
+is-symbol@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
 
 isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -516,6 +737,12 @@ jsonpointer@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
 
+jsx-ast-utils@^1.0.0, jsx-ast-utils@^1.3.4:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-1.4.0.tgz#5afe38868f56bc8cc7aeaef0100ba8c75bd12591"
+  dependencies:
+    object-assign "^4.1.0"
+
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
@@ -523,11 +750,25 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lodash@^4.0.0, lodash@^4.3.0:
+lodash.cond@^4.3.0:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
+
+lodash.pickby@^4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
+
+lodash@^4.0.0, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-minimatch@^3.0.2:
+loose-envify@^1.0.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
+  dependencies:
+    js-tokens "^3.0.0"
+
+minimatch@^3.0.2, minimatch@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
   dependencies:
@@ -542,6 +783,10 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
     minimist "0.0.8"
+
+ms@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.1.tgz#9cd13c03adbff25b65effde7ce864ee952017098"
 
 ms@0.7.2:
   version "0.7.2"
@@ -562,6 +807,18 @@ number-is-nan@^1.0.0:
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+object-keys@^1.0.10, object-keys@^1.0.8:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+
+object.assign@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.0.4.tgz#b1c9cc044ef1b9fe63606fc141abbb32e14730cc"
+  dependencies:
+    define-properties "^1.1.2"
+    function-bind "^1.1.0"
+    object-keys "^1.0.10"
 
 once@^1.3.0:
   version "1.4.0"
@@ -588,6 +845,12 @@ os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"
 
+path-exists@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
+  dependencies:
+    pinkie-promise "^2.0.0"
+
 path-is-absolute@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
@@ -609,6 +872,18 @@ pinkie-promise@^2.0.0:
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+
+pkg-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
+  dependencies:
+    find-up "^1.0.0"
+
+pkg-up@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-1.0.0.tgz#3e08fb461525c4421624a33b9f7e6d0af5b05a26"
+  dependencies:
+    find-up "^1.0.0"
 
 pluralize@^1.2.1:
   version "1.2.1"
@@ -651,6 +926,10 @@ rechoir@^0.6.2:
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
   dependencies:
     resolve "^1.1.6"
+
+regenerator-runtime@^0.10.0:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz#257f41961ce44558b18f7814af48c17559f9faeb"
 
 require-uncached@^1.0.2:
   version "1.0.3"
@@ -765,6 +1044,10 @@ text-table@~0.2.0:
 through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
+
+to-fast-properties@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.2.tgz#f3f5c0c3ba7299a7ef99427e44633257ade43320"
 
 tryit@^1.0.1:
   version "1.0.3"


### PR DESCRIPTION
Make our config extend from airbnb. Benefits:
- Aligns our coding style with what most developers are used to (reduces on-boarding friction).
- Simplifies our rules list, as we only need to override the rules from airbnb's config which we don't agree with.

**please note:** The migration is not fully complete yet. The following rules are disabled for now but will be enabled once our main repo is refactored to respect them:
```js
// Disallow declaration of variables already declared in the outer scope
'no-shadow': 'off',

// Disallow use of new operator when not part of the assignment or comparison
'no-new': 'off',

// Allow dangling underscores in identifiers
'no-underscore-dangle': 'off',

'comma-dangle': ['error', {
    'arrays': 'always-multiline',
    'objects': 'always-multiline',
    'imports': 'always-multiline',
    'exports': 'always-multiline',
    'functions': 'never', // airbnb sets this to 'always-multiline'
}],

'no-param-reassign': 'off',
'prefer-rest-params': 'off',
'prefer-spread': 'off',
'no-plusplus': 'off',
'no-restricted-syntax': 'off',
'default-case': 'off',
'no-multi-assign': 'off',
'no-prototype-builtins': 'off',
'no-mixed-operators': 'off',
'no-useless-escape': 'off',
'no-use-before-define': 'off',
'no-continue': 'off',
'no-lonely-if': 'off',
'import/prefer-default-export': 'off',
```