### PR TITLE
Breaking: get rid of a bunch of airbnb overrides

### DIFF
--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -157,15 +157,7 @@ module.exports = {
         }],
 
         'no-param-reassign': 'off',
-        'prefer-rest-params': 'off',
-        'prefer-spread': 'off',
-        'no-plusplus': 'off',
-        'no-restricted-syntax': 'off',
-        'default-case': 'off',
-        'no-multi-assign': 'off',
         'no-prototype-builtins': 'off',
-        'no-mixed-operators': 'off',
-        'no-useless-escape': 'off',
         'no-use-before-define': 'off',
         'no-continue': 'off',
         'no-lonely-if': 'off',
@@ -223,10 +215,8 @@ module.exports = {
         // Allow only one signature for modules definition
         'internations/valid-define': 'error',
 
-        // Don't allow fdescribe
+        // Don't allow fdescribe and fit
         'internations/no-fdescribe': 'error',
-
-        // Don't allow fit
         'internations/no-fit': 'error',
 
         'internations/routes': 'error',


### PR DESCRIPTION
Get rid of a bunch of rules that were overriding the defaults from airbnb. Our main repository already points to the commit id of this change, and all linter errors were already fixed.
