### PR TITLE
Disabled some rules in the latest ESLint version

### DIFF
--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -240,5 +240,14 @@ module.exports = {
         'wrap-iife': 'off',
         'no-extra-semi': 'off',
         'flowtype/space-after-type-colon': 'off',
+        'function-paren-newline': 'off',
+        'object-curly-newline': 'off',
+        'prefer-destructuring': ['error', {
+            'array': false
+        }],
+        'semi-style': 'off',
+        'jsx-a11y/anchor-is-valid': 'off',
+        'jsx-a11y/click-events-have-key-events': 'off',
+        'jsx-a11y/mouse-events-have-key-events': 'off',
     },
 };

--- a/lib/recommended-rules.js
+++ b/lib/recommended-rules.js
@@ -243,7 +243,7 @@ module.exports = {
         'function-paren-newline': 'off',
         'object-curly-newline': 'off',
         'prefer-destructuring': ['error', {
-            'array': false
+            'array': false,
         }],
         'semi-style': 'off',
         'jsx-a11y/anchor-is-valid': 'off',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-internations",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Custom ESLint rules and recommended rule configuration for internal InterNations usage",
   "author": "Vitor Balocco <vitorbal@gmail.com>",
   "main": "lib/index.js",
@@ -8,6 +8,10 @@
     {
       "name": "Francesco Zanini",
       "url": "https://twitter.com/zanini_me"
+    },
+    {
+      "name": "Craig Patik",
+      "url": "http://patik.com"
     }
   ],
   "dependencies": {


### PR DESCRIPTION
These conflict with prettier:

- `function-paren-newline`
- `object-curly-newline`
- `semi-style`

These are accessibility issues that will be addressed separately since touching them now could impact how some components function

- `jsx-a11y/anchor-is-valid`
- `jsx-a11y/click-events-have-key-events`
- `jsx-a11y/mouse-events-have-key-events`

And this one is just weird:

- `prefer-destructuring` (for arrays only)